### PR TITLE
Typo in "a new website"

### DIFF
--- a/content/blog/2011-11-05-darktable-and-research/2011-11-05-darktable-and-research.md
+++ b/content/blog/2011-11-05-darktable-and-research/2011-11-05-darktable-and-research.md
@@ -44,7 +44,7 @@ L and C gain are straight forward, it just enhances local contrast for the given
 
 the L and C thresholds (bottom curve, defaults to zero everywhere) affect the wavelet shrinkage step and result in denoising. select one of the denoising presets to get a feel of how to use it.
 
-the last tab gives you access to the edge-avoiding part of the wavelet transform. pull down the curve to all zero to reduce it to a standard, non-edge-aware wavelet. a double-click on any curve will reset it to it's default. to get a feel for the effect of the edge weight, start from the _sharpen (strong)_ preset and look at how high contrast edges change when playing with the sharpness curve.
+the last tab gives you access to the edge-avoiding part of the wavelet transform. pull down the curve to all zero to reduce it to a standard, non-edge-aware wavelet. a double-click on any curve will reset it to its default. to get a feel for the effect of the edge weight, start from the _sharpen (strong)_ preset and look at how high contrast edges change when playing with the sharpness curve.
 
 
 

--- a/content/blog/2017-12-12-a-new-website/2017-12-12-a-new-website.md
+++ b/content/blog/2017-12-12-a-new-website/2017-12-12-a-new-website.md
@@ -18,7 +18,7 @@ Baby New Year from 110 years ago ...
 
 houz and I have been working hard over the past few months to migrate the old website from Wordpress to a new static site, using [Python][]/[Pelican][].
 This should make things more secure and safer for both you and us (see the [problems that rawsamples.ch][rawsamples] had for the perils of using a db-driven backend for a website).
-Not to mention it makes collaboration and contributing a bit easier now, as the entire site gets it's [own GitHub repository][] (I'll be eagerly awaiting your pull requests).
+Not to mention it makes collaboration and contributing a bit easier now, as the entire site gets its [own GitHub repository][] (I'll be eagerly awaiting your pull requests).
 
 [Python]: https://www.python.org/ "Python homepage"
 [Pelican]: https://blog.getpelican.com/ "Pelican Static Site Generator"

--- a/content/pages/about/faq.md
+++ b/content/pages/about/faq.md
@@ -97,7 +97,7 @@ lede_author: <a href="https://jo.dreggn.org/home/">jo</a>
 
         Please be patient, currently you can not print. The Print module in darktable is using [CUPS](https://en.wikipedia.org/wiki/CUPS) on all operating systems, but that is not available on Windows. This means there was no easy way to port that functionality, and it will require further efforts to find a proper solution for printing in the Windows version as well. Until that time you can use your favorite image printing software separately to print the exported images.
 
-    * **I have started darktable and it's user interface is Finnish/Italian/Urdu/etc. How can I change the language of the user interface to English?**
+    * **I have started darktable and its user interface is Finnish/Italian/Urdu/etc. How can I change the language of the user interface to English?**
 
         By default darktable uses you operating system's language and if a localization is available in that language it will start using that localization for the user interface. You can override that and switch to an English user interface in multiple ways:
 


### PR DESCRIPTION
The text calls for pull-request, let's make one :-). "it's own GitHub" is not the contraction for "it is own ...", so spell it "its".