### PR TITLE
Implement "TODO" statements from home page

### DIFF
--- a/theme/dt.org/templates/home.html
+++ b/theme/dt.org/templates/home.html
@@ -140,7 +140,7 @@
                         darktable is created <em>for photographers, by photographers</em>.
                     </p>
                     <p>
-                    Mention that having (photographer) developers as part of the target audience is good for understanding the real world problems, challenges, and workflows.
+                    darktable developers understand your needs as photographers: they are photographers, too!
                     </p>
                 </div>
             </div>
@@ -158,7 +158,7 @@
             <div class='row'>
                 <div class='column'>
                     <p>
-                    Something about capability - highlight about some <a href="{{ SITEURL }}/about/features/" title="darktable Features">big important features</a>!  Maybe mention flexibility here (ease of writing new modules).
+                    darktable allows high-quality, non-destructive raw files editing. More than 60 modules (and counting!) are available to process your image, from basic raw processing to advanced image retouching. darktable makes no compromise on quality: it processes your images using 32 bits floating point numbers, and performs most operations in the Lab color space. The whole application is color-managed, allowing you to see the exact colors your image should be.
                     </p>
                 </div>
             </div>
@@ -175,10 +175,11 @@
         <div class='container content feature'>
             <div class='row'>
                 <div class='column'>
-                    <p>
-                    Something about community, <a href="{{ SITEURL }}/contact/#how-to-get-in-contact" title="How to get in contact">mailing list</a>, maybe <a href="https://discuss.pixls.us/c/software/darktable" title="darktable Category on PIXLS.US">discuss forum</a>, and the <a href="https://www.flickr.com/groups/1284326@N23/" title="darktable Flickr Group">Flickr</a> page?
-                    Number of contributors (indicate health of the project and users).
-                    Some other metric of vitality of the community (possibly <a href="https://github.com/darktable-org" title="darktable Repository on Github">how to get involved</a>)?
+                  <p>
+		    darktable has a very active community. You can get in contact with other users or developers via <a href="{{ SITEURL }}/contact/#how-to-get-in-contact" title="How to get in contact">mailing list</a>, <a href="https://discuss.pixls.us/c/software/darktable" title="darktable Category on PIXLS.US">discussion forum</a>, or the <a href="https://www.flickr.com/groups/1284326@N23/" title="darktable Flickr Group">Flickr</a> page.
+		  </p>
+		  <p>
+                    darktable was developed by <a href="https://www.openhub.net/p/darktable/contributors/summary">more than 320 contributors</a>, with a total of more than <a href="https://github.com/darktable-org/darktable">20,000 commits</a>. Everybody is <a href="https://github.com/darktable-org/darktable/blob/master/CONTRIBUTING.md">welcome to contribute</a>!
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
The home page is online, and was still including TODO-like statements
like "Mention that ...". Implement and remove such statements.

Feel free to amend or ignore my proposed text, but the current home page is
really drafty; it would be nice to get it to a better shape before the final 2.4 release.
At worse, deleting or commenting out the TODO statements can work, too.