### PR TITLE
Udadate contact.md removed google Plus

### DIFF
--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -7,7 +7,7 @@ lede_author: <a href="https://jo.dreggn.org/home/">jo</a>
 
 # Find us on...
 
-[Facebook](https://www.facebook.com/darktable)&nbsp;– [Flickr](https://www.flickr.com/groups/darktable/)&nbsp;– [Twitter](https://twitter.com/#!/darktable_org)&nbsp;– [Google+](https://www.google.com/+darktable)
+[Facebook](https://www.facebook.com/darktable)&nbsp;– [Flickr](https://www.flickr.com/groups/darktable/)&nbsp;– [Twitter](https://twitter.com/#!/darktable_org)
 
 # How to get in contact
 ![sun]({attach}sun.jpg)


### PR DESCRIPTION
As Google is closing Google Plus, I think we should remove it from the contact page too.