### PR TITLE
Static comment author

### DIFF
--- a/theme/dt.org/templates/article.html
+++ b/theme/dt.org/templates/article.html
@@ -178,7 +178,7 @@
                         <div>
                           <span class="static_comment_author">
                         {% if comment.author_url %}
-                          <a href="{{ SITEURL }}/{{ comment.author_url }}">{{ comment.author }}</a>
+                          <a href="{{ comment.author_url }}">{{ comment.author }}</a>
                         {% else %}
                           {{ comment.author }}
                         {% endif %}


### PR DESCRIPTION
The link should be absolute as it is a link to the personal website of the author.