### PR TITLE
stylesheet: improve mobile layout

### DIFF
--- a/theme/dt.org/static/css/darktable.css
+++ b/theme/dt.org/static/css/darktable.css
@@ -311,7 +311,7 @@ h1+h2, h2+h3, h3+h4, h4+h5, h5+h6 {
  */
 .page .content,
 .article .content {
-    padding: 1rem 3rem;
+    padding: 0.2rem;
 }
 @media (min-width: 750px){
     .page .content,

--- a/theme/dt.org/static/css/skeleton.css
+++ b/theme/dt.org/static/css/skeleton.css
@@ -340,6 +340,17 @@ th:last-child,
 td:last-child {
   /* padding-right: 0; */ }
 
+@media (max-width: 750px) {
+  table, tr, th, td {
+    padding: 0;
+    width: 100%;
+    display: block;
+  }
+  colgroup {
+    display: none;
+  }
+}
+
 
 /* Spacing
 –––––––––––––––––––––––––––––––––––––––––––––––––– */

--- a/theme/dt.org/static/css/usermanual.css
+++ b/theme/dt.org/static/css/usermanual.css
@@ -3,22 +3,34 @@ table, tr, th, td {
 }
 
 .breadcrumbs {
-  margin-top: -2rem;
-  margin-bottom: 1.5rem;
-  margin-left: -3rem;
   font-size: smaller;
 }
 
 .navheader {
   text-align: center;
-  margin: 0 -3rem;
   font-size: smaller;
 }
 
 .navfooter {
   text-align: center;
-  margin: 4rem -3rem 0 -3rem;
   font-size: smaller;
+}
+
+@media (min-width: 750px) {
+  .breadcrumbs {
+    margin-top: -2rem;
+    margin-bottom: 1.5rem;
+    margin-left: -3rem;
+  }
+
+  .navheader {
+    margin: 0 -3rem;
+  }
+
+  .navfooter {
+    margin: 4rem -3rem 0 -3rem;
+  }
+
 }
 
 .usermanual_nav_clear {


### PR DESCRIPTION
This greatly improves readability on mobile devices.

Screenshot of https://darktable.gitlab.io/doc/en/lighttable_panels.html before/after (Firefox 69 using responsive design mode 360×1200px):

![Screenshot_2019-10-07 “Lighttable panels” in the darktable usermanual(1)](https://user-images.githubusercontent.com/782446/66338661-e07dd600-e941-11e9-8f10-597f6be1bd26.png)

![Screenshot_2019-10-07 “Lighttable panels” in the darktable usermanual(2)](https://user-images.githubusercontent.com/782446/66338672-e4a9f380-e941-11e9-8026-b47107d60d37.png)
