### PR TITLE
Change order of Italian translator names in contact.md

### DIFF
--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -377,7 +377,7 @@ The translations of darktable are brought to you by:
 </td>
 <td>Italian
 </td>
-<td>Germano Massullo, Maurizio Paglia, Matteo Mardegan
+<td>Maurizio Paglia, Matteo Mardegan, Germano Massullo
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
I putted my name as last member of Italian translator team, since work on 3.0.0 has been done by other translators