### PR TITLE
updated supported ubuntu versions via OBS

### DIFF
--- a/content/pages/install.md
+++ b/content/pages/install.md
@@ -160,7 +160,7 @@ Right now this means for the stable package:
 * Debian 9, 10, Next aka Testing
 * Fedora  29, 30, 31, Rawhide
 * openSUSE 15.0, 15.1, Tumbleweed
-* Ubuntu 18.04, 19.04, 19.10, 20.04 (only lates release, not snapshot from stable release branch)
+* Ubuntu 18.04, 19.04, 19.10, 20.04 (only latest release, not snapshot from stable release branch)
 
 For master we build for the following distributions because of missing required packages in older distributions:
 


### PR DESCRIPTION
it's a little tricky, as apparently currently 20.04 is only supported by ("master branch" and) "latest release" but not by "snapshots from the stable release branch"...