### PR TITLE
Added Mastodon to footer

### DIFF
--- a/theme/dt.org/templates/footer.html
+++ b/theme/dt.org/templates/footer.html
@@ -42,6 +42,8 @@
                         &middot;
                         <a href='http://www.flickr.com/groups/darktable/' title='darktable on Flickr'>Flickr</a>
                         &middot;
+                        <a href='https://mastodon.social/@darktable' title='darktable on Mastodon'>Mastodon</a>
+                        &middot;
                         <a href='http://twitter.com/#!/darktable_org' title='darktable on Twitter'>Twitter</a>
                     </p>
 


### PR DESCRIPTION
Added Mastodon to footer. 
Mastodon appears at the top of the contact page but was missing in the footer (with the rest of social networks: facebook, twitter and flickr)