### PR TITLE
Link to manual at docs.darktable.org

### DIFF
--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -45,7 +45,7 @@ menu: "footer"
 
 * <a name="faq-moduleorder"></a>**How do I change the order in which modules are applied to an image?**<a href="#faq-moduleorder" class="anchor" title="Link to this FAQ entry">¶</a>
 
-    See the [user manual](https://docs.darktable.org/usermanual/3.8/en/darkroom/pixelpipe/the-pixelpipe-and-module-order/#changing-module-order) for more details.
+    See the [user manual](/usermanual/en/darkroom/pixelpipe/the-pixelpipe-and-module-order/#changing-module-order) for more details.
 
 * <a name="faq-modules"></a>**Modules? What modules?**<a href="#faq-modules" class="anchor" title="Link to this FAQ entry">¶</a>
 

--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -102,8 +102,8 @@ menu: "footer"
 
     Yes, there are two libraries we heavily rely on and which we point to quite often when people complain about darkable lacking something:
 
-    * **exiv2** is used for reading metadata from image files. If something isn't shown correctly in the [image information](https://docs.darktable.org/usermanual/4.0/en/module-reference/utility-modules/shared/image-information/) panel on the left side then please check with the command line tool `exiv2` and report any problems upstream on [their bug tracker](https://github.com/Exiv2/exiv2/issues)&nbsp;– there isn't much we can do to fix those things ourselves.
-    * **lensfun** is used for lens correction. If the [lens correction](https://docs.darktable.org/usermanual/4.0/en/module-reference/processing-modules/lens-correction/) module isn't showing your camera or lens, or a wrong one, then please report that to [those folks](https://github.com/lensfun/lensfun).
+    * **exiv2** is used for reading metadata from image files. If something isn't shown correctly in the [image information](https://docs.darktable.org/usermanual/stable/en/module-reference/utility-modules/shared/image-information/) panel on the left side then please check with the command line tool `exiv2` and report any problems upstream on [their bug tracker](https://github.com/Exiv2/exiv2/issues)&nbsp;– there isn't much we can do to fix those things ourselves.
+    * **lensfun** is used for lens correction. If the [lens correction](https://docs.darktable.org/usermanual/stable/en/module-reference/processing-modules/lens-correction/) module isn't showing your camera or lens, or a wrong one, then please report that to [those folks](https://github.com/lensfun/lensfun).
 
 * <a name="faq-windows"></a>**I see there is now a new Windows version, what can I expect?**<a href="#faq-windows" class="anchor" title="Link to this FAQ entry">¶</a>
 

--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -45,7 +45,7 @@ menu: "footer"
 
 * <a name="faq-moduleorder"></a>**How do I change the order in which modules are applied to an image?**<a href="#faq-moduleorder" class="anchor" title="Link to this FAQ entry">¶</a>
 
-    See the [user manual](/usermanual/en/darkroom/pixelpipe/the-pixelpipe-and-module-order/#changing-module-order) for more details.
+    See the [user manual](https://docs.darktable.org/usermanual/stable/en/darkroom/pixelpipe/the-pixelpipe-and-module-order/#changing-module-order) for more details.
 
 * <a name="faq-modules"></a>**Modules? What modules?**<a href="#faq-modules" class="anchor" title="Link to this FAQ entry">¶</a>
 
@@ -73,7 +73,7 @@ menu: "footer"
 
 * <a name="faq-docs"></a>**This confuses me. Is there a manual?**<a href="#faq-docs" class="anchor" title="Link to this FAQ entry">¶</a>
 
-    Yes, [here](/usermanual/en/). You might also want to read through the [blog section](/blog/) of this website.
+    Yes, [here](https://docs.darktable.org/usermanual/stable/en/). You might also want to read through the [blog section](/blog/) of this website.
 
 * <a name="faq-old-presets"></a>**My auto-applied presets aren't enabled for pictures imported before upgrade to version 1.1 (or higher), what's happening?**<a href="#faq-old-presets" class="anchor" title="Link to this FAQ entry">¶</a>
 
@@ -102,8 +102,8 @@ menu: "footer"
 
     Yes, there are two libraries we heavily rely on and which we point to quite often when people complain about darkable lacking something:
 
-    * **exiv2** is used for reading metadata from image files. If something isn't shown correctly in the [image information](/usermanual/en/image_information.html) panel on the left side then please check with the command line tool `exiv2` and report any problems upstream on [their bug tracker](https://github.com/Exiv2/exiv2/issues)&nbsp;– there isn't much we can do to fix those things ourselves.
-    * **lensfun** is used for lens correction. If the [lens correction](/usermanual/en/correction_group.html#lens_correction) module isn't showing your camera or lens, or a wrong one, then please report that to [those folks](https://github.com/lensfun/lensfun).
+    * **exiv2** is used for reading metadata from image files. If something isn't shown correctly in the [image information](https://docs.darktable.org/usermanual/4.0/en/module-reference/utility-modules/darkroom/image-info-line/) panel on the left side then please check with the command line tool `exiv2` and report any problems upstream on [their bug tracker](https://github.com/Exiv2/exiv2/issues)&nbsp;– there isn't much we can do to fix those things ourselves.
+    * **lensfun** is used for lens correction. If the [lens correction](https://docs.darktable.org/usermanual/4.0/en/module-reference/processing-modules/lens-correction/) module isn't showing your camera or lens, or a wrong one, then please report that to [those folks](https://github.com/lensfun/lensfun).
 
 * <a name="faq-windows"></a>**I see there is now a new Windows version, what can I expect?**<a href="#faq-windows" class="anchor" title="Link to this FAQ entry">¶</a>
 

--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -102,7 +102,7 @@ menu: "footer"
 
     Yes, there are two libraries we heavily rely on and which we point to quite often when people complain about darkable lacking something:
 
-    * **exiv2** is used for reading metadata from image files. If something isn't shown correctly in the [image information](https://docs.darktable.org/usermanual/4.0/en/module-reference/utility-modules/darkroom/image-info-line/) panel on the left side then please check with the command line tool `exiv2` and report any problems upstream on [their bug tracker](https://github.com/Exiv2/exiv2/issues)&nbsp;– there isn't much we can do to fix those things ourselves.
+    * **exiv2** is used for reading metadata from image files. If something isn't shown correctly in the [image information](https://docs.darktable.org/usermanual/4.0/en/module-reference/utility-modules/shared/image-information/) panel on the left side then please check with the command line tool `exiv2` and report any problems upstream on [their bug tracker](https://github.com/Exiv2/exiv2/issues)&nbsp;– there isn't much we can do to fix those things ourselves.
     * **lensfun** is used for lens correction. If the [lens correction](https://docs.darktable.org/usermanual/4.0/en/module-reference/processing-modules/lens-correction/) module isn't showing your camera or lens, or a wrong one, then please report that to [those folks](https://github.com/lensfun/lensfun).
 
 * <a name="faq-windows"></a>**I see there is now a new Windows version, what can I expect?**<a href="#faq-windows" class="anchor" title="Link to this FAQ entry">¶</a>


### PR DESCRIPTION
When linking to the user manual from the FAQs, use full links to `https://docs.darktable.org/usermanual/stable` instead of using relative links (on `www.darktable.org`) and relying on redirects.

In the process of editing and verifying links, I also noticed that the existing links to the "image information" and "lens correction" sections of the manual were broken. I've updated them to what I believe are the correct sections in the current manual.