### PR TITLE
resources: add links to manual for v4.2

### DIFF
--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -15,6 +15,15 @@ Some commonly asked questions can be found in our [FAQ](/about/faq). Please read
 
 # User manual
 
+## Version 4.2
+
+  * English [html](https://docs.darktable.org/usermanual/4.2/en/)/[epub](https://docs.darktable.org/usermanual/4.2/en/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.2/en/darktable_user_manual.pdf)
+  * Brazilian Portuguese [html](https://docs.darktable.org/usermanual/4.2/pt_br/)/[epub](https://docs.darktable.org/usermanual/4.2/pt_br/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.2/pt_br/darktable_user_manual.pdf)
+  * Dutch [html](https://docs.darktable.org/usermanual/4.2/nl/)/[epub](https://docs.darktable.org/usermanual/4.2/nl/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.2/nl/darktable_user_manual.pdf)
+  * German [html](https://docs.darktable.org/usermanual/4.2/de/)/[epub](https://docs.darktable.org/usermanual/4.2/de/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.2/de/darktable_user_manual.pdf)
+  * Polish [html](https://docs.darktable.org/usermanual/4.2/pl/)/[epub](https://docs.darktable.org/usermanual/4.2/pl/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.2/pl/darktable_user_manual.pdf)
+  * Ukrainian [html](https://docs.darktable.org/usermanual/4.2/uk/)/[epub](https://docs.darktable.org/usermanual/4.2/uk/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.2/uk/darktable_user_manual.pdf)
+
 ## Version 4.0
 
   * English [html](https://docs.darktable.org/usermanual/4.0/en/)/[epub](https://docs.darktable.org/usermanual/4.0/en/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.0/en/darktable_user_manual.pdf)


### PR DESCRIPTION
Site is missing links to manuals for Darktable 4.2. This PR adds them.