### PR TITLE
[blog] Fix the wrong rendering of inline images in a blog post

### DIFF
--- a/content/blog/2012-03-02-bauhaus-widgets/index.md
+++ b/content/blog/2012-03-02-bauhaus-widgets/index.md
@@ -19,14 +19,31 @@ for our purposes, i found the fundamental principles of the bauhaus school to be
 
 the second aspect about bauhaus is functionality. we want that, too, so without further philosophy, here is a use case example with the sharpen module:
 
+
 <span style="display: table-row;">
-<span style="display: table-cell">![sharpen_0011](sharpen_0011.jpg)</span>
+<span style="display: table-cell">
+
+![sharpen_0011](sharpen_0011.jpg)
+
+</span>
 &nbsp;
-<span style="display: table-cell">![sharpen_0010](sharpen_0010.jpg)</span>
+<span style="display: table-cell">
+
+![sharpen_0010](sharpen_0010.jpg)
+
+</span>
 &nbsp;
-<span style="display: table-cell">![sharpen_0009](sharpen_0009.jpg)</span>
+<span style="display: table-cell">
+
+![sharpen_0009](sharpen_0009.jpg)
+
+</span>
 &nbsp;
-<span style="display: table-cell">![sharpen_0008](sharpen_0008.jpg)</span>
+<span style="display: table-cell">
+
+![sharpen_0008](sharpen_0008.jpg)
+
+</span>
 </span>
 
 the first image shows the unfocussed module, which presents itself as plain text and minimal equilateral triangles representing the slider positions. note that all borders and distances follow the same grid, the slider's baseline is the text baseline, and everything uses the same font.
@@ -39,13 +56,32 @@ the last image demonstrates the same functionality we already have in master. wh
 so why do we need a new slider you may ask. it's not about the slider. it's about unifying the interface, both in design and in functionality. to illustrate what i mean, here goes another example, a combobox this time:
 
 <span style="display: table-row;">
-<span style="display: table-cell">![sharpen_0007](sharpen_0007.jpg)</span>
+<span style="display: table-cell">
+
+![sharpen_0007](sharpen_0007.jpg)
+
+</span>
 &nbsp;
-<span style="display: table-cell">![sharpen_0006](sharpen_0006.jpg)</span>
+<span style="display: table-cell">
+
+![sharpen_0006](sharpen_0006.jpg)
+
+</span>
 &nbsp;
-<span style="display: table-cell">![sharpen_0005](sharpen_0005.jpg)</span>
+
+<span style="display: table-cell">
+
+![sharpen_0005](sharpen_0005.jpg)
+
+</span>
 &nbsp;
-<span style="display: table-cell">![sharpen_0012](sharpen_0012.jpg)</span>
+
+<span style="display: table-cell">
+
+![sharpen_0012](sharpen_0012.jpg)
+
+</span>
+
 </span>
 
 one more thing to note about functionality is the included label. this way translations can vary in length wildly, and there is no need for an additional separation line in between label and the widget itself.


### PR DESCRIPTION
Apparently rendering broke when switching from Pelican to Hugo due to their different interpretation of markdown markup. Fortunately, Hugo implements CommonMark, so it is clear how to ensure that the HTML block is interpreted in the markdown code.
