### PR TITLE
Fix broken rendering of inline math formulas across the site

### DIFF
--- a/themes/darktable/layouts/partials/footer.html
+++ b/themes/darktable/layouts/partials/footer.html
@@ -69,3 +69,10 @@
 
   </div>
 </section>
+<script>
+MathJax = {
+    tex: {
+        inlineMath: [['$', '$'], ['\\(', '\\)']]
+    }
+};
+</script>


### PR DESCRIPTION
They apparently broke when switching from Pelikan to Hugo...
