### PR TITLE
Fix declaration of oldest supported macOS version

### DIFF
--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -64,7 +64,7 @@ The available packages are:
 
 <h2 id='macos'>macOS</h2>
 
-This bundle supports macOS versions starting with 10.14 (Mojave).
+These bundles support macOS versions starting with 11.3 (Big Sur).
 
 What to do with dialog saying *"darktable" can't be opened because it was not downloaded from the Mac App Store*:
 


### PR DESCRIPTION
See [Release Notes](https://github.com/darktable-org/dtorg/blob/master/content/news/2023-06-21-darktable-4.4.0-released/index.md?plain=1#L922-L923)
