### PR TITLE
Updates to FAQ plus link to FAQ in install page

### DIFF
--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -158,7 +158,7 @@ darktable is developed for linux, but it was ported to build on Windows. The [MS
     Don't panic, sometimes it happens. If you can reproduce the crash, please file a [bug report](https://github.com/darktable-org/darktable/issues), and send the so called "backtrace" file as well. You can find the location of this backtrace file in the folder where the crash dialog indicates. Generating a log of the crash can also aid in discovering the cause. The simplest way is to start Windows Command Prompt (cmd), navigate to `C:\Program files\darktable\bin` and start darktable via `darktable.exe -d common` or `darktable -d opencl` or `darktable -d perf` or to see all the options `darktable -h`. The log file will be generated in the hidden path listed above.
         
 ### <a name="faq-windows-issues"></a>**Known Windows issues**<a href="#faq-windows-issues" class="anchor" title="Link to this FAQ entry">¶</a>
-* OpenCL will speed up the processing in darktable. Sometimes Windows 11 preinstalls an OpenCL Compatibility app and it causes faults on darktable. Uninstall the Compatibility from Windows.
+* OpenCL will speed up the processing in darktable. Sometimes Windows 11 preinstalls an OpenCL Compatibility app and it causes faults on darktable. Uninstall the OpenCL Compatibility from Windows or start darktable using `darktable --disable-opencl`.
 
 * Windows 11 Pro security blocks installs. To resolve, go to Windows Security > App & Browsers Control > Exploit Protection Settings > Force Randomization and Set the Force Randomization for images (Mandatory ASLR) to "Off", and reboot Windows.
 

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -28,6 +28,8 @@ menu: ["main", "footer"]
 </div>
 </div>
 
+Some commonly asked questions can be found in our [FAQ](/about/faq). Please read it before reporting bugs or feature requests.
+
 <h1 id="linux">Linux/Unix Binary Packages</h1>
 
 ## From Your Package Manager


### PR DESCRIPTION
Added a link to the FAQ from the install page with the hope that folks will know there is a FAQ section. 

Added the clear option of starting with --disable-opencl for windows users