### PR TITLE
Make table headers sticky

### DIFF
--- a/static/css/darktable.css
+++ b/static/css/darktable.css
@@ -49,6 +49,12 @@ body {
     background-color: #f1f1f1;
 }
 
+thead th {
+  background-color: rgba(255, 255, 255, 0.5);
+  position: sticky;
+  top: 0;
+}
+
 #logo img {
     position: relative;
     margin: 1rem auto 0;


### PR DESCRIPTION
This makes table headers stay on top while scrolling. Originally did this for the "camera support" page. Not exactly sure on the colour, though.

![20240103_192219](https://github.com/darktable-org/dtorg/assets/51426724/fb20266e-cbd6-4555-af17-649a0d7d203f)
