### PR TITLE
Updating MacOS version to 12.5 in darktable.com

### DIFF
--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -60,7 +60,7 @@ The [OBS](https://build.opensuse.org/) allows packagers to provide packages for 
 
 <h2 id='macos'>macOS</h2>
 
-These bundles support macOS versions starting with 11.3 (Big Sur).
+These bundles support macOS versions starting with 12.5 (Monterey).
 
 ### Fixing issues with macOS security settings
 


### PR DESCRIPTION
The current darktable version 4.6.0 support MacOS version 12.5 and later.