### PR TITLE
Eliminate mailing lists, add matrix room

### DIFF
--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -17,11 +17,13 @@ menu: ["main", "footer"]
 
 Help/forum: [discuss.pixls.us](https://discuss.pixls.us)
 
-Report issues or feature requests:  [github issue](https://github.com/darktable-org/darktable/issues/new/choose).
+Report issues or feature requests:  [github issue](https://github.com/darktable-org/darktable/issues/new/choose)
 
-Code contributions or translation: [open a pull request](https://github.com/darktable-org/darktable/pulls).
+Code contributions or translation: [open a pull request](https://github.com/darktable-org/darktable/pulls)
 
 IRC: _irc.oftc.net_, channel _#darktable_ or use the [web interface](https://webchat.oftc.net/?channels=%23darktable)
+
+Matrix: [#darktable](https://matrix.to/#/#_oftc_#darktable:matrix.org) room (bridged with the IRC channel mentioned above)
 
 # Developers / darktable Team
 

--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -23,12 +23,6 @@ Code contributions or translation: [open a pull request](https://github.com/dark
 
 IRC: _irc.oftc.net_, channel _#darktable_ or use the [web interface](https://webchat.oftc.net/?channels=%23darktable)
 
-Mailing lists (last resort, posts by subscribers only):
-
-  * [development mailing list](https://www.mail-archive.com/darktable-dev@lists.darktable.org/): subscribe via email to `darktable-dev+subscribe@lists.darktable.org` and unsubscribe via email to `darktable-dev+unsubscribe@lists.darktable.org` (run by mlmmj).
-  * [user mailing list](https://www.mail-archive.com/darktable-user@lists.darktable.org/): subscribe via email to `darktable-user+subscribe@lists.darktable.org` and unsubscribe via email to `darktable-user+unsubscribe@lists.darktable.org` (run by mlmmj).
-  * [CI mailing list](https://www.mail-archive.com/darktable-ci@lists.darktable.org/) (Read-only, messages from automated test builds): `darktable-ci+subscribe@lists.darktable.org` (subscription may not work, mail Johannes directly in that case.) (run by mlmmj).
-
 # Developers / darktable Team
 
 Here are some members of our community:


### PR DESCRIPTION
As the title says.

"CI mailing list" actually no longer exists. The other two exist, but if we are going to sunset them, we can remove the mention of them now.
