### PR TITLE
Added v4.8 docs links in Resources tab

### DIFF
--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -15,6 +15,16 @@ Some commonly asked questions can be found in our [FAQ](/about/faq). Please read
 
 # User manual
 
+## Version 4.8
+
+  * English [html](https://docs.darktable.org/usermanual/4.8/en/)/[epub](https://docs.darktable.org/usermanual/4.8/en/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.8/en/darktable_user_manual.pdf)
+  * Brazilian Portuguese [html](https://docs.darktable.org/usermanual/4.8/pt_br/)/[epub](https://docs.darktable.org/usermanual/4.8/pt_br/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.8/pt_br/darktable_user_manual.pdf)
+  * Dutch [html](https://docs.darktable.org/usermanual/4.8/nl/)/[epub](https://docs.darktable.org/usermanual/4.8/nl/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.8/nl/darktable_user_manual.pdf)
+  * French [html](https://docs.darktable.org/usermanual/4.8/fr/)/[epub](https://docs.darktable.org/usermanual/4.8/fr/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.8/fr/darktable_user_manual.pdf)
+  * German [html](https://docs.darktable.org/usermanual/4.8/de/)/[epub](https://docs.darktable.org/usermanual/4.8/de/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.8/de/darktable_user_manual.pdf)
+  * Polish [html](https://docs.darktable.org/usermanual/4.8/pl/)/[epub](https://docs.darktable.org/usermanual/4.8/pl/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.8/pl/darktable_user_manual.pdf)
+  * Ukrainian [html](https://docs.darktable.org/usermanual/4.8/uk/)/[epub](https://docs.darktable.org/usermanual/4.8/uk/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.8/uk/darktable_user_manual.pdf)
+
 ## Version 4.6
 
   * English [html](https://docs.darktable.org/usermanual/4.6/en/)/[epub](https://docs.darktable.org/usermanual/4.6/en/darktable_user_manual.epub)/[pdf](https://docs.darktable.org/usermanual/4.6/en/darktable_user_manual.pdf)


### PR DESCRIPTION
This PR adds v4.8, which is the current stable release, to the resources page as it's missing