### PR TITLE
remove link to dtstyle.net because site no longer exists

### DIFF
--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -82,10 +82,6 @@ Please note that the following translations are not complete (and will not be up
 
 [html](https://docs.darktable.org/lua/stable/)
 
-# darktable Styles
-
-dtsytles an online repository with darktable styles available for download at <https://dtstyle.net/>. It features live preview of the styles with four different sample images.
-
 # Videos
 
   * [Bruce Williams](https://www.youtube.com/playlist?list=PLlYWvzmJQTrRq7JrYdD7k3-8-v-uHnhK_)


### PR DESCRIPTION
The site is displaying the following notice:

    Due to a multi disk crash in the server, i lost all the data to dtstyle.net.
    I have no ambition to rebuild it. If anyone feels like building something
    simular and is intrested in the domain. You can find me as andabata on:
    irc: irc.oftc.net #pixls.us
    web: pixls.us

    Cheers and goodbye
    andabata