### PR TITLE
Add instructions on testing without using make to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Then, run `make server` and navigate to `http://localhost:1313`.
 
 ### Without make
 
-Testing the site without `make` installed may be easier in some cases, especially on windows. On these systems, you must first [install Hugo](https://gohugo.io/installation/) manually, then run `rm -rf public && hugo server --renderStaticToDisk` and navigate to `http://localhost:1313`.
+Testing the site without `make` installed may be easier in some cases, especially on windows. On these systems, you must first [install Hugo](https://gohugo.io/installation/) manually, then run hugo server --renderStaticToDisk` and navigate to `http://localhost:1313`.


### PR DESCRIPTION
This makes it easier to contribute on Windows.

It's probably worth considering whether `make` is really needed at all, but I'll leave that question to more experienced contributors.