### PR TITLE
Move to wiki link for contributing camera calibrations

### DIFF
--- a/content/development/_index.md
+++ b/content/development/_index.md
@@ -19,19 +19,19 @@ menu: "footer"
 
 If you feel like contributing to this project, here are a few suggestions.
 
-## Testing:
+## Testing
 
 Just use it! And afterwards let us know how you like it. Send your _bug reports_, _feature requests_, _suggestions_ or just your personal opinion to our [mailing list](/contact/#how-to-get-in-contact). You can file a bug to our [bug tracker](https://github.com/darktable-org/darktable/issues) as well&nbsp;– but you want to discuss it first (on IRC or mailing list).
 
 If you found a bug or managed to crash darktable, please submit a _helpful backtrace_! Instructions are below.
 
-## Translating:
+## Translating
 
 A short introduction can be found in our git repository,  [TRANSLATORS.md](https://github.com/darktable-org/darktable/blob/master/doc/TRANSLATORS.md).
 
-## Supplying a color matrix for your camera:
+## Calibrating Cameras
 
-Color matrices are specifications on how camera-native color is transformed into something that an end user might like, and ideally will be correct when viewed on a calibrated display. Read more about this in Pascal’s [detailed blog post](https://web.archive.org/web/20230517192227/https://encrypted.pcode.nl/blog/2010/06/28/darktable-camera-color-profiling/).
+There are several aspects that go into fully supporting a camera in darktable to make your photos look as good as possible out of the box, starting with file format support(requiring test images from our users). Once your camera is functional in darktable, you can submit white balance presets, noise profiles, and more. See [Camera Support](https://github.com/darktable-org/darktable/wiki/Camera-support) on the development wiki for details.
 
 
 ## Coding


### PR DESCRIPTION
Follows up on #288 

I don't think the wiki page on the main repo is fully up to date either, but it's both far more recent and more in depth than the archived blog post, and can be updated further because it's under our control. 

<img width="967" height="295" alt="image" src="https://github.com/user-attachments/assets/c6681853-2d12-452e-9dac-e2b454748efe" />
