### PR TITLE
Describe additional Mac installation error

### DIFF
--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -73,16 +73,16 @@ These bundles support macOS versions starting with 13.5 (Ventura).
 
 Depending on the version of macOS, there maybe some warnings causing darktable not to run.
 
-#### Dialog: *"darktable" can't be opened because it was not downloaded from the Mac App Store*
+#### Dialog: *"darktable" can't be opened because it was not downloaded from the Mac App Store* or *Apple could not verify "darktable.app" is free from malware*
+
+Do one of the following:
 
 1. Locate darktable in Applications folder (or wherever you installed it) using Finder
 2. Do "Open" via context menu
-3. You will be presented with similar-looking dialog, but this time there will be second button allowing you to run the application
+3. You will be presented with similar-looking dialog, but this time there will be second button allowing you to run the application. If not, proceed to the next solution
 4. After that you will be able to start darktable without this trick (well, until you update it, then you will have to do above steps again)
 
-or use the following solution:
-
-### Dialog: *Apple could not verify "darktable.app" is free from malware*
+or
 
 1. Open the Terminal app.
 2. Do one of the following:


### PR DESCRIPTION
The error 'macOS cannot verify "darktable.app" is free from malware' happens on MacOS 15.7.2 when installing a nightly build or the official release. This error deserves a separate section since the usual workaround (open the app via the context menu) does not give any option to bypass the warning, so we shouldn't write that as a solution.

<img width="259" height="264" alt="image" src="https://github.com/user-attachments/assets/58a8c1ee-bd6d-4f3b-b7dd-ad8f2b0832cd" />

My other PR (#292) had a branch/merge issue so I'm recreating it.