### PR TITLE
remove homebrew command

### DIFF
--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -99,7 +99,3 @@ or
 MacPorts:
 
     sudo port install darktable +quartz
-
-Homebrew:
-
-    brew install --cask darktable


### PR DESCRIPTION
This is now [deprecated](https://formulae.brew.sh/cask/darktable#default) by the looks of things, so probably best to remove it entirely.

Macports looks behind too, but i guess this isn't intentional?